### PR TITLE
Empty list selection behavior

### DIFF
--- a/ui/listchoices.go
+++ b/ui/listchoices.go
@@ -78,7 +78,7 @@ func NewListChoices() *ListChoices {
 			lc.LeftList.Select(lc.LeftList.Length() - 1)
 		}
 		if lc.LeftList.Length() == 0 {
-			lc.MoveRightButton.Disable()
+			lc.RightList.Select(0)
 		}
 	}
 	lc.MoveLeftButton.OnTapped = func() {
@@ -99,7 +99,7 @@ func NewListChoices() *ListChoices {
 			lc.RightList.Select(lc.RightList.Length() - 1)
 		}
 		if lc.RightList.Length() == 0 {
-			lc.MoveLeftButton.Disable()
+			lc.LeftList.Select(0)
 		}
 	}
 

--- a/ui/listchoices_test.go
+++ b/ui/listchoices_test.go
@@ -79,15 +79,8 @@ func TestListChoices_TagMovingButtonTapsMoveTags(t *testing.T) {
 		assert.Equal(t, numRemove, lc.RightList.Length())
 		assert.Equal(t, len(allFollowedTags)-numRemove, lc.LeftList.Length())
 	}
-
-	// // Move all tags back to left list
-	// for numRemove := 1; numRemove <= len(allFollowedTags); numRemove++ {
-	// 	lc.RightList.Select(0)
-	// 	assert.False(t, lc.MoveLeftButton.Disabled(), "Move left button should be enabled when right item selected")
-	// 	test.Tap(lc.MoveLeftButton)
-	// 	assert.Equal(t, numRemove, lc.LeftList.Length())
-	// 	assert.Equal(t, len(allFollowedTags)-numRemove, lc.RightList.Length())
-	// }
+	assert.True(t, lc.MoveRightButton.Disabled(), "Move right button diabled")
+	assert.False(t, lc.MoveLeftButton.Disabled(), "Move left button disabled")
 
 	expectedLeftLen := 0
 	expectedRightLen := len(allFollowedTags)
@@ -103,9 +96,9 @@ func TestListChoices_TagMovingButtonTapsMoveTags(t *testing.T) {
 		expectedRightLen--
 		assert.Equal(t, expectedLeftLen, lc.LeftList.Length())
 		assert.Equal(t, expectedRightLen, lc.RightList.Length())
-
 	}
-}
+	assert.False(t, lc.MoveRightButton.Disabled(), "Move right button diabled")
+	assert.True(t, lc.MoveLeftButton.Disabled(), "Move left button disabled")}
 
 func TestListChoices_TagMovingButtonsMoveTagsSelectingFirstListItems(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
When all items of one list have been moved, select the first item of the other list.  This prevents both Move buttons from being disabled.